### PR TITLE
ensure Registry.toStream returns a stream

### DIFF
--- a/.changeset/hip-apples-count.md
+++ b/.changeset/hip-apples-count.md
@@ -1,0 +1,5 @@
+---
+"@effect-rx/rx": patch
+---
+
+ensure Registry.toStream returns a stream

--- a/packages/rx/src/Registry.ts
+++ b/packages/rx/src/Registry.ts
@@ -106,8 +106,8 @@ export const layer: Layer.Layer<Registry.RxRegistry> = layerOptions()
  * @category Conversions
  */
 export const toStream: {
-  <A>(rx: Rx.Rx<A>): (self: Registry) => Stream.Stream<A>
-  <A>(self: Registry, rx: Rx.Rx<A>): Stream.Stream<A>
+  <A>(rx: Rx.Rx<A>): (self: Registry) => Effect.Effect<Stream.Stream<A>, never, Scope.Scope>
+  <A>(self: Registry, rx: Rx.Rx<A>): Effect.Effect<Stream.Stream<A>, never, Scope.Scope>
 } = dual(
   2,
   <A>(self: Registry, rx: Rx.Rx<A>) =>
@@ -135,16 +135,21 @@ export const toStream: {
  * @category Conversions
  */
 export const toStreamResult: {
-  <A, E>(rx: Rx.Rx<Result.Result<A, E>>): (self: Registry) => Stream.Stream<A, E>
-  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>): Stream.Stream<A, E>
+  <A, E>(rx: Rx.Rx<Result.Result<A, E>>): (self: Registry) => Effect.Effect<Stream.Stream<A, E>, never, Scope.Scope>
+  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>):  Effect.Effect<Stream.Stream<A, E>, never, Scope.Scope>
 } = dual(
   2,
-  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>): Stream.Stream<A, E, RxRegistry> =>
+  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>):  Effect.Effect<Stream.Stream<A, E, RxRegistry>, never, Scope.Scope> =>
     toStream(self, rx).pipe(
-      Stream.filter(Result.isNotInitial),
-      Stream.mapEffect((result) =>
-        result._tag === "Success" ? Effect.succeed(result.value) : Effect.failCause(result.cause)
+      Effect.map((stream) => 
+        stream.pipe(
+          Stream.filter(Result.isNotInitial),
+          Stream.mapEffect((result) =>
+            result._tag === "Success" ? Effect.succeed(result.value) : Effect.failCause(result.cause)
+          )
+        )
       )
+      
     )
 )
 

--- a/packages/rx/src/Registry.ts
+++ b/packages/rx/src/Registry.ts
@@ -116,7 +116,9 @@ export const toStream: {
         const scope = Context.get(context, Scope.Scope)
         return Mailbox.make<A>().pipe(
           Effect.tap((mailbox) => {
-            const cancel = self.subscribe(rx, (value) => mailbox.unsafeOffer(value))
+            const cancel = self.subscribe(rx, (value) => mailbox.unsafeOffer(value), {
+              immediate: true
+            })
             return Scope.addFinalizer(
               scope,
               Effect.suspend(() => {

--- a/packages/rx/src/Registry.ts
+++ b/packages/rx/src/Registry.ts
@@ -106,8 +106,8 @@ export const layer: Layer.Layer<Registry.RxRegistry> = layerOptions()
  * @category Conversions
  */
 export const toStream: {
-  <A>(rx: Rx.Rx<A>): (self: Registry) => Effect.Effect<Stream.Stream<A>, never, Scope.Scope>
-  <A>(self: Registry, rx: Rx.Rx<A>): Effect.Effect<Stream.Stream<A>, never, Scope.Scope>
+  <A>(rx: Rx.Rx<A>): (self: Registry) => Stream.Stream<A, never, Scope.Scope>
+  <A>(self: Registry, rx: Rx.Rx<A>): Stream.Stream<A, never, Scope.Scope>
 } = dual(
   2,
   <A>(self: Registry, rx: Rx.Rx<A>) =>
@@ -127,7 +127,9 @@ export const toStream: {
         Effect.uninterruptible,
         Effect.map((mailbox) => Mailbox.toStream(mailbox))
       )
-    })
+    }).pipe(
+      Stream.unwrap,
+    )
 )
 
 /**
@@ -135,21 +137,16 @@ export const toStream: {
  * @category Conversions
  */
 export const toStreamResult: {
-  <A, E>(rx: Rx.Rx<Result.Result<A, E>>): (self: Registry) => Effect.Effect<Stream.Stream<A, E>, never, Scope.Scope>
-  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>):  Effect.Effect<Stream.Stream<A, E>, never, Scope.Scope>
+  <A, E>(rx: Rx.Rx<Result.Result<A, E>>): (self: Registry) => Stream.Stream<A, E, RxRegistry | Scope.Scope>
+  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>): Stream.Stream<A, E, RxRegistry | Scope.Scope>
 } = dual(
   2,
-  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>):  Effect.Effect<Stream.Stream<A, E, RxRegistry>, never, Scope.Scope> =>
+  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>): Stream.Stream<A, E, RxRegistry | Scope.Scope> =>
     toStream(self, rx).pipe(
-      Effect.map((stream) => 
-        stream.pipe(
-          Stream.filter(Result.isNotInitial),
-          Stream.mapEffect((result) =>
-            result._tag === "Success" ? Effect.succeed(result.value) : Effect.failCause(result.cause)
-          )
-        )
+      Stream.filter(Result.isNotInitial),
+      Stream.mapEffect((result) =>
+        result._tag === "Success" ? Effect.succeed(result.value) : Effect.failCause(result.cause)
       )
-      
     )
 )
 

--- a/packages/rx/src/Rx.ts
+++ b/packages/rx/src/Rx.ts
@@ -1518,14 +1518,14 @@ function updateSearchParams() {
  * @since 1.0.0
  * @category Conversions
  */
-export const toStream = <A>(self: Rx<A>): Stream.Stream<A, never, RxRegistry | Scope.Scope> =>
+export const toStream = <A>(self: Rx<A>): Stream.Stream<A, never, RxRegistry> =>
   Stream.unwrap(Effect.map(RxRegistry, Registry.toStream(self)))
 
 /**
  * @since 1.0.0
  * @category Conversions
  */
-export const toStreamResult = <A, E>(self: Rx<Result.Result<A, E>>): Stream.Stream<A, E, RxRegistry | Scope.Scope> =>
+export const toStreamResult = <A, E>(self: Rx<Result.Result<A, E>>): Stream.Stream<A, E, RxRegistry> =>
   Stream.unwrap(Effect.map(RxRegistry, Registry.toStreamResult(self)))
 
 /**

--- a/packages/rx/src/Rx.ts
+++ b/packages/rx/src/Rx.ts
@@ -1519,14 +1519,14 @@ function updateSearchParams() {
  * @category Conversions
  */
 export const toStream = <A>(self: Rx<A>): Stream.Stream<A, never, RxRegistry | Scope.Scope> =>
-  Stream.unwrap(Effect.flatMap(RxRegistry, Registry.toStream(self)))
+  Stream.unwrap(Effect.map(RxRegistry, Registry.toStream(self)))
 
 /**
  * @since 1.0.0
  * @category Conversions
  */
 export const toStreamResult = <A, E>(self: Rx<Result.Result<A, E>>): Stream.Stream<A, E, RxRegistry | Scope.Scope> =>
-  Stream.unwrap(Effect.flatMap(RxRegistry, Registry.toStreamResult(self)))
+  Stream.unwrap(Effect.map(RxRegistry, Registry.toStreamResult(self)))
 
 /**
  * @since 1.0.0

--- a/packages/rx/src/Rx.ts
+++ b/packages/rx/src/Rx.ts
@@ -1518,15 +1518,15 @@ function updateSearchParams() {
  * @since 1.0.0
  * @category Conversions
  */
-export const toStream = <A>(self: Rx<A>): Stream.Stream<A, never, RxRegistry> =>
-  Stream.unwrap(Effect.map(RxRegistry, Registry.toStream(self)))
+export const toStream = <A>(self: Rx<A>): Stream.Stream<A, never, RxRegistry | Scope.Scope> =>
+  Stream.unwrap(Effect.flatMap(RxRegistry, Registry.toStream(self)))
 
 /**
  * @since 1.0.0
  * @category Conversions
  */
-export const toStreamResult = <A, E>(self: Rx<Result.Result<A, E>>): Stream.Stream<A, E, RxRegistry> =>
-  Stream.unwrap(Effect.map(RxRegistry, Registry.toStreamResult(self)))
+export const toStreamResult = <A, E>(self: Rx<Result.Result<A, E>>): Stream.Stream<A, E, RxRegistry | Scope.Scope> =>
+  Stream.unwrap(Effect.flatMap(RxRegistry, Registry.toStreamResult(self)))
 
 /**
  * @since 1.0.0

--- a/packages/rx/test/Rx.test.ts
+++ b/packages/rx/test/Rx.test.ts
@@ -911,7 +911,7 @@ describe("Rx", () => {
     cancel()
   })
 
-  test.only(`toStream`, async () => {
+  test(`toStream`, async () => {
     vitest.useFakeTimers()
     const r = Registry.make()
     const rx = Rx.make(() => {


### PR DESCRIPTION
Hi Tim, I believe there is a type signature issue in Rx.toStream / Registry.toStream implementation
```typescript
export const toStream = <A>(self: Rx<A>): Stream.Stream<A, never, RxRegistry> =>
  Stream.unwrap(Effect.map(RxRegistry, Registry.toStream(self)))
```

Registry.toStream although has result type signature Stream<...> is in fact Effect<Stream>, which bubbles up as
Stream.Stream<Stream.Stream<A, never, RxRegistry>>.