### PR TITLE
add hydration support

### DIFF
--- a/.changeset/rich-wings-take.md
+++ b/.changeset/rich-wings-take.md
@@ -1,0 +1,6 @@
+---
+"@effect-rx/rx-react": patch
+"@effect-rx/rx": patch
+---
+
+add Hydration module

--- a/docs/rx-react/Hooks.ts.md
+++ b/docs/rx-react/Hooks.ts.md
@@ -1,0 +1,176 @@
+---
+title: Hooks.ts
+nav_order: 1
+parent: "@effect-rx/rx-react"
+---
+
+## Hooks overview
+
+Added in v1.0.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [hooks](#hooks)
+  - [useRx](#userx)
+  - [useRxInitialValues](#userxinitialvalues)
+  - [useRxMount](#userxmount)
+  - [useRxRef](#userxref)
+  - [useRxRefProp](#userxrefprop)
+  - [useRxRefPropValue](#userxrefpropvalue)
+  - [useRxRefresh](#userxrefresh)
+  - [useRxSet](#userxset)
+  - [useRxSetPromise](#userxsetpromise)
+  - [useRxSubscribe](#userxsubscribe)
+  - [useRxSuspense](#userxsuspense)
+  - [useRxSuspenseSuccess](#userxsuspensesuccess)
+  - [useRxValue](#userxvalue)
+
+---
+
+# hooks
+
+## useRx
+
+**Signature**
+
+```ts
+export declare const useRx: <R, W>(
+  rx: Rx.Writable<R, W>
+) => readonly [value: R, setOrUpdate: (_: W | ((_: R) => W)) => void]
+```
+
+Added in v1.0.0
+
+## useRxInitialValues
+
+**Signature**
+
+```ts
+export declare const useRxInitialValues: (initialValues: Iterable<readonly [Rx.Rx<any>, any]>) => void
+```
+
+Added in v1.0.0
+
+## useRxMount
+
+**Signature**
+
+```ts
+export declare const useRxMount: <A>(rx: Rx.Rx<A>) => void
+```
+
+Added in v1.0.0
+
+## useRxRef
+
+**Signature**
+
+```ts
+export declare const useRxRef: <A>(ref: RxRef.ReadonlyRef<A>) => A
+```
+
+Added in v1.0.0
+
+## useRxRefProp
+
+**Signature**
+
+```ts
+export declare const useRxRefProp: <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K) => RxRef.RxRef<A[K]>
+```
+
+Added in v1.0.0
+
+## useRxRefPropValue
+
+**Signature**
+
+```ts
+export declare const useRxRefPropValue: <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K) => A[K]
+```
+
+Added in v1.0.0
+
+## useRxRefresh
+
+**Signature**
+
+```ts
+export declare const useRxRefresh: <A>(rx: Rx.Rx<A>) => () => void
+```
+
+Added in v1.0.0
+
+## useRxSet
+
+**Signature**
+
+```ts
+export declare const useRxSet: <R, W>(rx: Rx.Writable<R, W>) => (_: W | ((_: R) => W)) => void
+```
+
+Added in v1.0.0
+
+## useRxSetPromise
+
+**Signature**
+
+```ts
+export declare const useRxSetPromise: <E, A, W>(
+  rx: Rx.Writable<Result.Result<A, E>, W>
+) => (_: W) => Promise<Exit.Exit<A, E>>
+```
+
+Added in v1.0.0
+
+## useRxSubscribe
+
+**Signature**
+
+```ts
+export declare const useRxSubscribe: <A>(
+  rx: Rx.Rx<A>,
+  f: (_: A) => void,
+  options?: { readonly immediate?: boolean }
+) => void
+```
+
+Added in v1.0.0
+
+## useRxSuspense
+
+**Signature**
+
+```ts
+export declare const useRxSuspense: <A, E>(
+  rx: Rx.Rx<Result.Result<A, E>>,
+  options?: { readonly suspendOnWaiting?: boolean }
+) => Result.Success<A, E> | Result.Failure<A, E>
+```
+
+Added in v1.0.0
+
+## useRxSuspenseSuccess
+
+**Signature**
+
+```ts
+export declare const useRxSuspenseSuccess: <A, E>(
+  rx: Rx.Rx<Result.Result<A, E>>,
+  options?: { readonly suspendOnWaiting?: boolean }
+) => Result.Success<A, E>
+```
+
+Added in v1.0.0
+
+## useRxValue
+
+**Signature**
+
+```ts
+export declare const useRxValue: { <A>(rx: Rx.Rx<A>): A; <A, B>(rx: Rx.Rx<A>, f: (_: A) => B): B }
+```
+
+Added in v1.0.0

--- a/docs/rx-react/ReactHydration.ts.md
+++ b/docs/rx-react/ReactHydration.ts.md
@@ -1,0 +1,33 @@
+---
+title: ReactHydration.ts
+nav_order: 3
+parent: "@effect-rx/rx-react"
+---
+
+## ReactHydration overview
+
+Added in v1.0.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [components](#components)
+  - [HydrationBoundary](#hydrationboundary)
+
+---
+
+# components
+
+## HydrationBoundary
+
+**Signature**
+
+```ts
+export declare const HydrationBoundary: React.FC<{
+  state: Iterable<Hydration.DehydratedRx>
+  children?: React.ReactNode
+}>
+```
+
+Added in v1.0.0

--- a/docs/rx-react/RegistryContext.ts.md
+++ b/docs/rx-react/RegistryContext.ts.md
@@ -1,0 +1,58 @@
+---
+title: RegistryContext.ts
+nav_order: 4
+parent: "@effect-rx/rx-react"
+---
+
+## RegistryContext overview
+
+Added in v1.0.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [context](#context)
+  - [RegistryContext](#registrycontext)
+  - [RegistryProvider](#registryprovider)
+  - [scheduleTask](#scheduletask)
+
+---
+
+# context
+
+## RegistryContext
+
+**Signature**
+
+```ts
+export declare const RegistryContext: React.Context<Registry.Registry>
+```
+
+Added in v1.0.0
+
+## RegistryProvider
+
+**Signature**
+
+```ts
+export declare const RegistryProvider: (options: {
+  readonly children?: React.ReactNode | undefined
+  readonly initialValues?: Iterable<readonly [Rx.Rx<any>, any]> | undefined
+  readonly scheduleTask?: ((f: () => void) => void) | undefined
+  readonly timeoutResolution?: number | undefined
+  readonly defaultIdleTTL?: number | undefined
+}) => React.FunctionComponentElement<React.ProviderProps<Registry.Registry>>
+```
+
+Added in v1.0.0
+
+## scheduleTask
+
+**Signature**
+
+```ts
+export declare function scheduleTask(f: () => void): void
+```
+
+Added in v1.0.0

--- a/docs/rx-react/index.ts.md
+++ b/docs/rx-react/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 1
+nav_order: 2
 parent: "@effect-rx/rx-react"
 ---
 
@@ -13,216 +13,74 @@ Added in v1.0.0
 <h2 class="text-delta">Table of contents</h2>
 
 - [context](#context)
-  - [RegistryContext](#registrycontext)
-  - [RegistryProvider](#registryprovider)
-  - [scheduleTask](#scheduletask)
-- [hooks](#hooks)
-  - [useRx](#userx)
-  - [useRxInitialValues](#userxinitialvalues)
-  - [useRxMount](#userxmount)
-  - [useRxRef](#userxref)
-  - [useRxRefProp](#userxrefprop)
-  - [useRxRefPropValue](#userxrefpropvalue)
-  - [useRxRefresh](#userxrefresh)
-  - [useRxSet](#userxset)
-  - [useRxSetPromise](#userxsetpromise)
-  - [useRxSubscribe](#userxsubscribe)
-  - [useRxSuspense](#userxsuspense)
-  - [useRxSuspenseSuccess](#userxsuspensesuccess)
-  - [useRxValue](#userxvalue)
-- [modules](#modules)
-  - [From "@effect-rx/rx/Registry"](#from-effect-rxrxregistry)
-  - [From "@effect-rx/rx/Result"](#from-effect-rxrxresult)
+  - [From "./RegistryContext.js"](#from-registrycontextjs)
+- [exports](#exports)
   - [From "@effect-rx/rx/Rx"](#from-effect-rxrxrx)
+- [hooks](#hooks)
+  - [From "./Hooks.js"](#from-hooksjs)
+- [re-exports](#re-exports)
+  - [From "@effect-rx/rx/Hydration"](#from-effect-rxrxhydration)
+  - [From "@effect-rx/rx/Registry"](#from-effect-rxrxregistry)
+  - [From "@effect-rx/rx/Registry"](#from-effect-rxrxregistry-1)
   - [From "@effect-rx/rx/RxRef"](#from-effect-rxrxrxref)
 
 ---
 
 # context
 
-## RegistryContext
+## From "./RegistryContext.js"
+
+Re-exports all named exports from the "./RegistryContext.js" module.
 
 **Signature**
 
 ```ts
-export declare const RegistryContext: React.Context<Registry.Registry>
+export * from "./RegistryContext.js"
 ```
 
 Added in v1.0.0
 
-## RegistryProvider
+# exports
+
+## From "@effect-rx/rx/Rx"
+
+Re-exports all named exports from the "@effect-rx/rx/Rx" module as `Rx`.
 
 **Signature**
 
 ```ts
-export declare const RegistryProvider: (options: {
-  readonly children?: React.ReactNode | undefined
-  readonly initialValues?: Iterable<readonly [Rx.Rx<any>, any]> | undefined
-  readonly scheduleTask?: ((f: () => void) => void) | undefined
-  readonly timeoutResolution?: number | undefined
-  readonly defaultIdleTTL?: number | undefined
-}) => React.FunctionComponentElement<React.ProviderProps<Registry.Registry>>
-```
-
-Added in v1.0.0
-
-## scheduleTask
-
-**Signature**
-
-```ts
-export declare function scheduleTask(f: () => void): void
+export * as Rx from "@effect-rx/rx/Rx"
 ```
 
 Added in v1.0.0
 
 # hooks
 
-## useRx
+## From "./Hooks.js"
+
+Re-exports all named exports from the "./Hooks.js" module.
 
 **Signature**
 
 ```ts
-export declare const useRx: <R, W>(
-  rx: Rx.Writable<R, W>
-) => readonly [value: R, setOrUpdate: (_: W | ((_: R) => W)) => void]
+export * from "./Hooks.js"
 ```
 
 Added in v1.0.0
 
-## useRxInitialValues
+# re-exports
+
+## From "@effect-rx/rx/Hydration"
+
+Re-exports all named exports from the "@effect-rx/rx/Hydration" module as `Hydration`.
 
 **Signature**
 
 ```ts
-export declare const useRxInitialValues: (initialValues: Iterable<readonly [Rx.Rx<any>, any]>) => void
+export * as Hydration from "@effect-rx/rx/Hydration"
 ```
 
 Added in v1.0.0
-
-## useRxMount
-
-**Signature**
-
-```ts
-export declare const useRxMount: <A>(rx: Rx.Rx<A>) => void
-```
-
-Added in v1.0.0
-
-## useRxRef
-
-**Signature**
-
-```ts
-export declare const useRxRef: <A>(ref: RxRef.ReadonlyRef<A>) => A
-```
-
-Added in v1.0.0
-
-## useRxRefProp
-
-**Signature**
-
-```ts
-export declare const useRxRefProp: <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K) => RxRef.RxRef<A[K]>
-```
-
-Added in v1.0.0
-
-## useRxRefPropValue
-
-**Signature**
-
-```ts
-export declare const useRxRefPropValue: <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K) => A[K]
-```
-
-Added in v1.0.0
-
-## useRxRefresh
-
-**Signature**
-
-```ts
-export declare const useRxRefresh: <A>(rx: Rx.Rx<A> & Rx.Refreshable) => () => void
-```
-
-Added in v1.0.0
-
-## useRxSet
-
-**Signature**
-
-```ts
-export declare const useRxSet: <R, W>(rx: Rx.Writable<R, W>) => (_: W | ((_: R) => W)) => void
-```
-
-Added in v1.0.0
-
-## useRxSetPromise
-
-**Signature**
-
-```ts
-export declare const useRxSetPromise: <E, A, W>(
-  rx: Rx.Writable<Result.Result<A, E>, W>
-) => (_: W) => Promise<Exit.Exit<A, E>>
-```
-
-Added in v1.0.0
-
-## useRxSubscribe
-
-**Signature**
-
-```ts
-export declare const useRxSubscribe: <A>(
-  rx: Rx.Rx<A>,
-  f: (_: A) => void,
-  options?: { readonly immediate?: boolean }
-) => void
-```
-
-Added in v1.0.0
-
-## useRxSuspense
-
-**Signature**
-
-```ts
-export declare const useRxSuspense: <A, E>(
-  rx: Rx.Rx<Result.Result<A, E>>,
-  options?: { readonly suspendOnWaiting?: boolean }
-) => Result.Success<A, E> | Result.Failure<A, E>
-```
-
-Added in v1.0.0
-
-## useRxSuspenseSuccess
-
-**Signature**
-
-```ts
-export declare const useRxSuspenseSuccess: <A, E>(
-  rx: Rx.Rx<Result.Result<A, E>>,
-  options?: { readonly suspendOnWaiting?: boolean }
-) => Result.Success<A, E>
-```
-
-Added in v1.0.0
-
-## useRxValue
-
-**Signature**
-
-```ts
-export declare const useRxValue: { <A>(rx: Rx.Rx<A>): A; <A, B>(rx: Rx.Rx<A>, f: (_: A) => B): B }
-```
-
-Added in v1.0.0
-
-# modules
 
 ## From "@effect-rx/rx/Registry"
 
@@ -236,26 +94,14 @@ export * as Registry from "@effect-rx/rx/Registry"
 
 Added in v1.0.0
 
-## From "@effect-rx/rx/Result"
+## From "@effect-rx/rx/Registry"
 
-Re-exports all named exports from the "@effect-rx/rx/Result" module as `Result`.
-
-**Signature**
-
-```ts
-export * as Result from "@effect-rx/rx/Result"
-```
-
-Added in v1.0.0
-
-## From "@effect-rx/rx/Rx"
-
-Re-exports all named exports from the "@effect-rx/rx/Rx" module as `Rx`.
+Re-exports all named exports from the "@effect-rx/rx/Registry" module as `Result`.
 
 **Signature**
 
 ```ts
-export * as Rx from "@effect-rx/rx/Rx"
+export * as Result from "@effect-rx/rx/Registry"
 ```
 
 Added in v1.0.0

--- a/docs/rx/Hydration.ts.md
+++ b/docs/rx/Hydration.ts.md
@@ -1,0 +1,69 @@
+---
+title: Hydration.ts
+nav_order: 1
+parent: "@effect-rx/rx"
+---
+
+## Hydration overview
+
+Added in v1.0.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [dehydration](#dehydration)
+  - [dehydrate](#dehydrate)
+- [hydration](#hydration)
+  - [hydrate](#hydrate)
+- [models](#models)
+  - [DehydratedRx (interface)](#dehydratedrx-interface)
+
+---
+
+# dehydration
+
+## dehydrate
+
+**Signature**
+
+```ts
+export declare const dehydrate: (
+  registry: Registry.Registry,
+  options?: { readonly shouldDehydrateRx?: ((rx: Rx.Rx<any> & Rx.Serializable) => boolean) | undefined }
+) => Array<DehydratedRx>
+```
+
+Added in v1.0.0
+
+# hydration
+
+## hydrate
+
+**Signature**
+
+```ts
+export declare const hydrate: (
+  registry: Registry.Registry,
+  dehydratedState: Iterable<DehydratedRx>,
+  options?: { readonly shouldHydrateRx?: ((dehydratedRx: DehydratedRx) => boolean) | undefined }
+) => void
+```
+
+Added in v1.0.0
+
+# models
+
+## DehydratedRx (interface)
+
+**Signature**
+
+```ts
+export interface DehydratedRx {
+  readonly key: string
+  readonly value: unknown
+  readonly dehydratedAt: number
+}
+```
+
+Added in v1.0.0

--- a/docs/rx/Registry.ts.md
+++ b/docs/rx/Registry.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Registry.ts
-nav_order: 2
+nav_order: 3
 parent: "@effect-rx/rx"
 ---
 
@@ -65,8 +65,8 @@ Added in v1.0.0
 
 ```ts
 export declare const toStreamResult: {
-  <A, E>(rx: Rx.Rx<Result.Result<A, E>>): (self: Registry) => Stream.Stream<A, E>
-  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>): Stream.Stream<A, E>
+  <A, E>(rx: Rx.Rx<Result.Result<A, E>>): (self: Registry) => Stream.Stream<A, E, RxRegistry>
+  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>): Stream.Stream<A, E, RxRegistry>
 }
 ```
 
@@ -141,10 +141,12 @@ Added in v1.0.0
 ```ts
 export interface Registry {
   readonly [TypeId]: TypeId
+  readonly getNodes: () => ReadonlyMap<Rx.Rx<any> | string, Node<any>>
   readonly get: <A>(rx: Rx.Rx<A>) => A
   readonly mount: <A>(rx: Rx.Rx<A>) => () => void
-  readonly refresh: <A>(rx: Rx.Rx<A> & Rx.Refreshable) => void
+  readonly refresh: <A>(rx: Rx.Rx<A>) => void
   readonly set: <R, W>(rx: Rx.Writable<R, W>, value: W) => void
+  readonly setSerializable: (key: string, encoded: unknown) => void
   readonly modify: <R, W, A>(rx: Rx.Writable<R, W>, f: (_: R) => [returnValue: A, nextValue: W]) => A
   readonly update: <R, W>(rx: Rx.Writable<R, W>, f: (_: R) => W) => void
   readonly subscribe: <A>(

--- a/docs/rx/Result.ts.md
+++ b/docs/rx/Result.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Result.ts
-nav_order: 3
+nav_order: 4
 parent: "@effect-rx/rx"
 ---
 
@@ -12,6 +12,13 @@ Added in v1.0.0
 
 <h2 class="text-delta">Table of contents</h2>
 
+- [Guards](#guards)
+  - [isResult](#isresult)
+- [Schemas](#schemas)
+  - [Encoded (type alias)](#encoded-type-alias)
+  - [PartialEncoded (type alias)](#partialencoded-type-alias)
+  - [Schema](#schema)
+  - [schemaFromSelf](#schemafromself)
 - [accessors](#accessors)
   - [cause](#cause)
   - [getOrElse](#getorelse)
@@ -56,6 +63,103 @@ Added in v1.0.0
   - [TypeId (type alias)](#typeid-type-alias)
 
 ---
+
+# Guards
+
+## isResult
+
+**Signature**
+
+```ts
+export declare const isResult: (u: unknown) => u is Result<unknown, unknown>
+```
+
+Added in v1.0.0
+
+# Schemas
+
+## Encoded (type alias)
+
+**Signature**
+
+```ts
+export type Encoded<A, E> =
+  | {
+      readonly _tag: "Initial"
+      readonly waiting: boolean
+    }
+  | {
+      readonly _tag: "Success"
+      readonly waiting: boolean
+      readonly value: A
+    }
+  | {
+      readonly _tag: "Failure"
+      readonly waiting: boolean
+      readonly previousValue: Schema_.OptionEncoded<A>
+      readonly cause: Schema_.CauseEncoded<E, unknown>
+    }
+```
+
+Added in v1.0.0
+
+## PartialEncoded (type alias)
+
+**Signature**
+
+```ts
+export type PartialEncoded<A, E> =
+  | {
+      readonly _tag: "Initial"
+      readonly waiting: boolean
+    }
+  | {
+      readonly _tag: "Success"
+      readonly waiting: boolean
+      readonly value: A
+    }
+  | {
+      readonly _tag: "Failure"
+      readonly waiting: boolean
+      readonly previousValue: Option.Option<A>
+      readonly cause: Cause.Cause<E>
+    }
+```
+
+Added in v1.0.0
+
+## Schema
+
+**Signature**
+
+```ts
+export declare const Schema: <
+  Success extends Schema_.Schema.All = typeof Schema_.Never,
+  Error extends Schema_.Schema.All = typeof Schema_.Never
+>(options: {
+  readonly success?: Success | undefined
+  readonly error?: Error | undefined
+}) => Schema_.transform<
+  Schema_.Schema<
+    PartialEncoded<Success["Type"], Error["Type"]>,
+    Encoded<Success["Encoded"], Error["Encoded"]>,
+    Success["Context"] | Error["Context"]
+  >,
+  Schema_.Schema<Result<Success["Type"], Error["Type"]>>
+>
+```
+
+Added in v1.0.0
+
+## schemaFromSelf
+
+**Signature**
+
+```ts
+export declare const schemaFromSelf: Schema_.Schema<Result<any, any>, Result<any, any>, never>
+```
+
+Added in v1.0.0
 
 # accessors
 

--- a/docs/rx/Rx.ts.md
+++ b/docs/rx/Rx.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Rx.ts
-nav_order: 4
+nav_order: 5
 parent: "@effect-rx/rx"
 ---
 
@@ -16,12 +16,21 @@ Added in v1.0.0
   - [get](#get)
   - [getResult](#getresult)
   - [modify](#modify)
+  - [refresh](#refresh)
   - [set](#set)
   - [toStream](#tostream)
   - [toStreamResult](#tostreamresult)
   - [update](#update)
+- [Focus](#focus)
+  - [makeRefreshOnSignal](#makerefreshonsignal)
+  - [windowFocusSignal](#windowfocussignal)
 - [KeyValueStore](#keyvaluestore)
   - [kvs](#kvs)
+- [Serializable](#serializable)
+  - [Serializable (interface)](#serializable-interface)
+  - [SerializableTypeId](#serializabletypeid)
+  - [SerializableTypeId (type alias)](#serializabletypeid-type-alias)
+  - [isSerializable](#isserializable)
 - [URL search params](#url-search-params)
   - [searchParam](#searchparam)
 - [batching](#batching)
@@ -32,7 +41,8 @@ Added in v1.0.0
   - [keepAlive](#keepalive)
   - [map](#map)
   - [mapResult](#mapresult)
-  - [refreshable](#refreshable)
+  - [refreshOnWindowFocus](#refreshonwindowfocus)
+  - [serializable](#serializable-1)
   - [setIdleTTL](#setidlettl)
   - [setLazy](#setlazy)
   - [transform](#transform)
@@ -57,7 +67,6 @@ Added in v1.0.0
 - [models](#models)
   - [FnContext (interface)](#fncontext-interface)
   - [PullResult (type alias)](#pullresult-type-alias)
-  - [Refreshable (interface)](#refreshable-interface)
   - [RuntimeFactory (interface)](#runtimefactory-interface)
   - [Rx (interface)](#rx-interface)
   - [Rx (namespace)](#rx-namespace)
@@ -65,6 +74,7 @@ Added in v1.0.0
     - [InferFailure (type alias)](#inferfailure-type-alias)
     - [InferPullSuccess (type alias)](#inferpullsuccess-type-alias)
     - [InferSuccess (type alias)](#infersuccess-type-alias)
+    - [WithoutSerializable (type alias)](#withoutserializable-type-alias)
   - [RxResultFn (interface)](#rxresultfn-interface)
   - [RxRuntime (interface)](#rxruntime-interface)
   - [Writable (interface)](#writable-interface)
@@ -74,8 +84,6 @@ Added in v1.0.0
   - [Reset](#reset)
   - [Reset (type alias)](#reset-type-alias)
 - [type ids](#type-ids)
-  - [RefreshableTypeId](#refreshabletypeid)
-  - [RefreshableTypeId (type alias)](#refreshabletypeid-type-alias)
   - [TypeId](#typeid)
   - [TypeId (type alias)](#typeid-type-alias)
   - [WritableTypeId](#writabletypeid)
@@ -117,6 +125,16 @@ export declare const modify: {
   <R, W, A>(f: (_: R) => [returnValue: A, nextValue: W]): (self: Writable<R, W>) => Effect.Effect<A, never, RxRegistry>
   <R, W, A>(self: Writable<R, W>, f: (_: R) => [returnValue: A, nextValue: W]): Effect.Effect<A, never, RxRegistry>
 }
+```
+
+Added in v1.0.0
+
+## refresh
+
+**Signature**
+
+```ts
+export declare const refresh: <A>(self: Rx<A>) => Effect.Effect<void, never, RxRegistry>
 ```
 
 Added in v1.0.0
@@ -167,6 +185,30 @@ export declare const update: {
 
 Added in v1.0.0
 
+# Focus
+
+## makeRefreshOnSignal
+
+**Signature**
+
+```ts
+export declare const makeRefreshOnSignal: <_>(
+  signal: Rx<_>
+) => <A extends Rx<any>>(self: A) => Rx.WithoutSerializable<A>
+```
+
+Added in v1.0.0
+
+## windowFocusSignal
+
+**Signature**
+
+```ts
+export declare const windowFocusSignal: Rx<number>
+```
+
+Added in v1.0.0
+
 # KeyValueStore
 
 ## kvs
@@ -180,6 +222,54 @@ export declare const kvs: <A>(options: {
   readonly schema: Schema.Schema<A, any>
   readonly defaultValue: LazyArg<A>
 }) => Writable<A>
+```
+
+Added in v1.0.0
+
+# Serializable
+
+## Serializable (interface)
+
+**Signature**
+
+```ts
+export interface Serializable {
+  readonly [SerializableTypeId]: {
+    readonly key: string
+    readonly encode: (value: unknown) => unknown
+    readonly decode: (value: unknown) => unknown
+  }
+}
+```
+
+Added in v1.0.0
+
+## SerializableTypeId
+
+**Signature**
+
+```ts
+export declare const SerializableTypeId: typeof SerializableTypeId
+```
+
+Added in v1.0.0
+
+## SerializableTypeId (type alias)
+
+**Signature**
+
+```ts
+export type SerializableTypeId = typeof SerializableTypeId
+```
+
+Added in v1.0.0
+
+## isSerializable
+
+**Signature**
+
+```ts
+export declare const isSerializable: (self: Rx<any>) => self is Rx<any> & Serializable
 ```
 
 Added in v1.0.0
@@ -223,8 +313,8 @@ Added in v1.0.0
 
 ```ts
 export declare const debounce: {
-  (duration: Duration.DurationInput): <A extends Rx<any>>(self: A) => A
-  <A extends Rx<any>>(self: A, duration: Duration.DurationInput): A
+  (duration: Duration.DurationInput): <A extends Rx<any>>(self: A) => Rx.WithoutSerializable<A>
+  <A extends Rx<any>>(self: A, duration: Duration.DurationInput): Rx.WithoutSerializable<A>
 }
 ```
 
@@ -295,12 +385,31 @@ export declare const mapResult: {
 
 Added in v1.0.0
 
-## refreshable
+## refreshOnWindowFocus
 
 **Signature**
 
 ```ts
-export declare const refreshable: <T extends Rx<any>>(self: T) => T & Refreshable
+export declare const refreshOnWindowFocus: <A extends Rx<any>>(self: A) => Rx.WithoutSerializable<A>
+```
+
+Added in v1.0.0
+
+## serializable
+
+**Signature**
+
+```ts
+export declare const serializable: {
+  <R extends Rx<any>, I>(options: {
+    readonly key: string
+    readonly schema: Schema.Schema<Rx.Infer<R>, I>
+  }): (self: R) => R & Serializable
+  <R extends Rx<any>, I>(
+    self: R,
+    options: { readonly key: string; readonly schema: Schema.Schema<Rx.Infer<R>, I> }
+  ): R & Serializable
+}
 ```
 
 Added in v1.0.0
@@ -580,7 +689,7 @@ export interface Context {
   readonly once: <A>(rx: Rx<A>) => A
   readonly addFinalizer: (f: () => void) => void
   readonly mount: <A>(rx: Rx<A>) => void
-  readonly refresh: <A>(rx: Rx<A> & Refreshable) => void
+  readonly refresh: <A>(rx: Rx<A>) => void
   readonly refreshSelf: () => void
   readonly self: <A>() => Option.Option<A>
   readonly setSelf: <A>(a: A) => void
@@ -679,18 +788,6 @@ export type PullResult<A, E = never> = Result.Result<
 
 Added in v1.0.0
 
-## Refreshable (interface)
-
-**Signature**
-
-```ts
-export interface Refreshable {
-  readonly [RefreshableTypeId]: RefreshableTypeId
-}
-```
-
-Added in v1.0.0
-
 ## RuntimeFactory (interface)
 
 **Signature**
@@ -763,6 +860,17 @@ Added in v1.0.0
 
 ```ts
 export type InferSuccess<T extends Rx<any>> = T extends Rx<Result.Result<infer A, infer _>> ? A : never
+```
+
+Added in v1.0.0
+
+### WithoutSerializable (type alias)
+
+**Signature**
+
+```ts
+export type WithoutSerializable<T extends Rx<any>> =
+  T extends Writable<infer R, infer W> ? Writable<R, W> : Rx<Infer<T>>
 ```
 
 Added in v1.0.0
@@ -913,26 +1021,6 @@ export type Reset = typeof Reset
 Added in v1.0.0
 
 # type ids
-
-## RefreshableTypeId
-
-**Signature**
-
-```ts
-export declare const RefreshableTypeId: typeof RefreshableTypeId
-```
-
-Added in v1.0.0
-
-## RefreshableTypeId (type alias)
-
-**Signature**
-
-```ts
-export type RefreshableTypeId = typeof RefreshableTypeId
-```
-
-Added in v1.0.0
 
 ## TypeId
 

--- a/docs/rx/RxRef.ts.md
+++ b/docs/rx/RxRef.ts.md
@@ -1,6 +1,6 @@
 ---
 title: RxRef.ts
-nav_order: 5
+nav_order: 6
 parent: "@effect-rx/rx"
 ---
 

--- a/docs/rx/index.ts.md
+++ b/docs/rx/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 1
+nav_order: 2
 parent: "@effect-rx/rx"
 ---
 
@@ -13,6 +13,7 @@ Added in v1.0.0
 <h2 class="text-delta">Table of contents</h2>
 
 - [exports](#exports)
+  - [From "./Hydration.js"](#from-hydrationjs)
   - [From "./Registry.js"](#from-registryjs)
   - [From "./Result.js"](#from-resultjs)
   - [From "./Rx.js"](#from-rxjs)
@@ -21,6 +22,18 @@ Added in v1.0.0
 ---
 
 # exports
+
+## From "./Hydration.js"
+
+Re-exports all named exports from the "./Hydration.js" module as `Hydration`.
+
+**Signature**
+
+```ts
+export * as Hydration from "./Hydration.js"
+```
+
+Added in v1.0.0
 
 ## From "./Registry.js"
 

--- a/packages/rx-react/package.json
+++ b/packages/rx-react/package.json
@@ -3,17 +3,9 @@
   "version": "0.38.1",
   "description": "Reactive toolkit for Effect",
   "type": "module",
-  "exports": {
-    ".": {
-      "import": "./build/esm/index.js",
-      "require": "./build/cjs/index.js",
-      "types": "./build/dts/index.d.ts"
-    },
-    "./*": {
-      "import": "./build/esm/*.js",
-      "require": "./build/cjs/*.js",
-      "types": "./build/dts/*.d.ts"
-    }
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
   },
   "repository": {
     "type": "git",
@@ -21,7 +13,6 @@
   },
   "homepage": "https://github.com/effect-ts/rx",
   "scripts": {
-    "build:watch": "tsc -b tsconfig.build.json --watch",
     "build": "pnpm build-esm && pnpm build-cjs && pnpm build-annotate && build-utils pack-v2",
     "build-esm": "tsc -b tsconfig.build.json",
     "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",

--- a/packages/rx-react/package.json
+++ b/packages/rx-react/package.json
@@ -3,9 +3,17 @@
   "version": "0.38.1",
   "description": "Reactive toolkit for Effect",
   "type": "module",
-  "publishConfig": {
-    "access": "public",
-    "directory": "dist"
+  "exports": {
+    ".": {
+      "import": "./build/esm/index.js",
+      "require": "./build/cjs/index.js",
+      "types": "./build/dts/index.d.ts"
+    },
+    "./*": {
+      "import": "./build/esm/*.js",
+      "require": "./build/cjs/*.js",
+      "types": "./build/dts/*.d.ts"
+    }
   },
   "repository": {
     "type": "git",
@@ -13,6 +21,7 @@
   },
   "homepage": "https://github.com/effect-ts/rx",
   "scripts": {
+    "build:watch": "tsc -b tsconfig.build.json --watch",
     "build": "pnpm build-esm && pnpm build-cjs && pnpm build-annotate && build-utils pack-v2",
     "build-esm": "tsc -b tsconfig.build.json",
     "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",

--- a/packages/rx-react/src/Hooks.ts
+++ b/packages/rx-react/src/Hooks.ts
@@ -1,7 +1,7 @@
-"use client"
 /**
  * @since 1.0.0
  */
+"use client"
 import type * as Registry from "@effect-rx/rx/Registry"
 import * as Result from "@effect-rx/rx/Result"
 import * as Rx from "@effect-rx/rx/Rx"

--- a/packages/rx-react/src/Hooks.ts
+++ b/packages/rx-react/src/Hooks.ts
@@ -1,0 +1,285 @@
+"use client"
+/**
+ * @since 1.0.0
+ */
+import type * as Registry from "@effect-rx/rx/Registry"
+import * as Result from "@effect-rx/rx/Result"
+import * as Rx from "@effect-rx/rx/Rx"
+import type * as RxRef from "@effect-rx/rx/RxRef"
+import * as Cause from "effect/Cause"
+import type * as Exit from "effect/Exit"
+import { globalValue } from "effect/GlobalValue"
+import * as React from "react"
+import { RegistryContext } from "./RegistryContext.js"
+
+interface RxStore<A> {
+  readonly subscribe: (f: () => void) => () => void
+  readonly snapshot: () => A
+}
+
+const storeRegistry = globalValue(
+  "@effect-rx/rx-react/storeRegistry",
+  () => new WeakMap<Registry.Registry, WeakMap<Rx.Rx<any>, RxStore<any>>>()
+)
+
+function makeStore<A>(registry: Registry.Registry, rx: Rx.Rx<A>): RxStore<A> {
+  let stores = storeRegistry.get(registry)
+  if (stores === undefined) {
+    stores = new WeakMap()
+    storeRegistry.set(registry, stores)
+  }
+  const store = stores.get(rx)
+  if (store !== undefined) {
+    return store
+  }
+  const newStore: RxStore<A> = {
+    subscribe(f) {
+      return registry.subscribe(rx, f)
+    },
+    snapshot() {
+      return registry.get(rx)
+    }
+  }
+  stores.set(rx, newStore)
+  return newStore
+}
+
+function useStore<A>(registry: Registry.Registry, rx: Rx.Rx<A>): A {
+  const store = makeStore(registry, rx)
+  return React.useSyncExternalStore(store.subscribe, store.snapshot, store.snapshot)
+}
+
+const initialValuesSet = globalValue(
+  "@effect-rx/rx-react/initialValuesSet",
+  () => new WeakMap<Registry.Registry, WeakSet<Rx.Rx<any>>>()
+)
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxInitialValues = (initialValues: Iterable<readonly [Rx.Rx<any>, any]>): void => {
+  const registry = React.useContext(RegistryContext)
+  let set = initialValuesSet.get(registry)
+  if (set === undefined) {
+    set = new WeakSet()
+    initialValuesSet.set(registry, set)
+  }
+  for (const [rx, value] of initialValues) {
+    if (!set.has(rx)) {
+      set.add(rx)
+      ;(registry as any).ensureNode(rx).setValue(value)
+    }
+  }
+}
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxValue: {
+  <A>(rx: Rx.Rx<A>): A
+  <A, B>(rx: Rx.Rx<A>, f: (_: A) => B): B
+} = <A>(rx: Rx.Rx<A>, f?: (_: A) => A): A => {
+  const registry = React.useContext(RegistryContext)
+  if (f) {
+    const rxB = React.useMemo(() => Rx.map(rx, f), [rx, f])
+    return useStore(registry, rxB)
+  }
+  return useStore(registry, rx)
+}
+
+function mountRx<A>(registry: Registry.Registry, rx: Rx.Rx<A>): void {
+  React.useEffect(() => registry.mount(rx), [rx, registry])
+}
+
+function setRx<R, W>(registry: Registry.Registry, rx: Rx.Writable<R, W>): (_: W | ((_: R) => W)) => void {
+  return React.useCallback((value) => {
+    if (typeof value === "function") {
+      registry.set(rx, (value as any)(registry.get(rx)))
+      return
+    } else {
+      registry.set(rx, value)
+    }
+  }, [registry, rx])
+}
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxMount = <A>(rx: Rx.Rx<A>): void => {
+  const registry = React.useContext(RegistryContext)
+  mountRx(registry, rx)
+}
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxSet = <R, W>(rx: Rx.Writable<R, W>): (_: W | ((_: R) => W)) => void => {
+  const registry = React.useContext(RegistryContext)
+  mountRx(registry, rx)
+  return setRx(registry, rx)
+}
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxSetPromise = <E, A, W>(
+  rx: Rx.Writable<Result.Result<A, E>, W>
+): (_: W) => Promise<Exit.Exit<A, E>> => {
+  const registry = React.useContext(RegistryContext)
+  const resolves = React.useMemo(() => new Set<(result: Exit.Exit<A, E>) => void>(), [])
+  React.useEffect(() =>
+    registry.subscribe(rx, (result) => {
+      if (result.waiting || result._tag === "Initial") return
+      const fns = Array.from(resolves)
+      resolves.clear()
+      const exit = Result.toExit(result)
+      fns.forEach((resolve) => resolve(exit as any))
+    }, { immediate: true }), [registry, rx, resolves])
+  return React.useCallback((value) =>
+    new Promise((resolve) => {
+      resolves.add(resolve)
+      registry.set(rx, value)
+    }), [registry, rx, resolves])
+}
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxRefresh = <A>(rx: Rx.Rx<A>): () => void => {
+  const registry = React.useContext(RegistryContext)
+  mountRx(registry, rx)
+  return React.useCallback(() => {
+    registry.refresh(rx)
+  }, [registry, rx])
+}
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRx = <R, W>(
+  rx: Rx.Writable<R, W>
+): readonly [value: R, setOrUpdate: (_: W | ((_: R) => W)) => void] => {
+  const registry = React.useContext(RegistryContext)
+  return [
+    useStore(registry, rx),
+    setRx(registry, rx)
+  ] as const
+}
+
+const rxPromiseMap = globalValue(
+  "@effect-rx/rx-react/rxPromiseMap",
+  () => ({
+    suspendOnWaiting: new Map<Rx.Rx<any>, Promise<void>>(),
+    default: new Map<Rx.Rx<any>, Promise<void>>()
+  })
+)
+
+function rxToPromise<A, E>(
+  registry: Registry.Registry,
+  rx: Rx.Rx<Result.Result<A, E>>,
+  suspendOnWaiting: boolean
+) {
+  const map = suspendOnWaiting ? rxPromiseMap.suspendOnWaiting : rxPromiseMap.default
+  let promise = map.get(rx)
+  if (promise !== undefined) {
+    return promise
+  }
+  promise = new Promise<void>((resolve) => {
+    const dispose = registry.subscribe(rx, (result) => {
+      if (result._tag === "Initial" || (suspendOnWaiting && result.waiting)) {
+        return
+      }
+      setTimeout(dispose, 1000)
+      resolve()
+      map.delete(rx)
+    })
+  })
+  map.set(rx, promise)
+  return promise
+}
+
+function rxResultOrSuspend<A, E>(
+  registry: Registry.Registry,
+  rx: Rx.Rx<Result.Result<A, E>>,
+  suspendOnWaiting: boolean
+) {
+  const value = useStore(registry, rx)
+  if (value._tag === "Initial" || (suspendOnWaiting && value.waiting)) {
+    throw rxToPromise(registry, rx, suspendOnWaiting)
+  }
+  return value
+}
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxSuspense = <A, E>(
+  rx: Rx.Rx<Result.Result<A, E>>,
+  options?: { readonly suspendOnWaiting?: boolean }
+): Result.Success<A, E> | Result.Failure<A, E> => {
+  const registry = React.useContext(RegistryContext)
+  return rxResultOrSuspend(registry, rx, options?.suspendOnWaiting ?? false)
+}
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxSuspenseSuccess = <A, E>(
+  rx: Rx.Rx<Result.Result<A, E>>,
+  options?: { readonly suspendOnWaiting?: boolean }
+): Result.Success<A, E> => {
+  const result = useRxSuspense(rx, options)
+  if (result._tag === "Failure") {
+    throw Cause.squash(result.cause)
+  }
+  return result
+}
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxSubscribe = <A>(
+  rx: Rx.Rx<A>,
+  f: (_: A) => void,
+  options?: { readonly immediate?: boolean }
+): void => {
+  const registry = React.useContext(RegistryContext)
+  React.useEffect(
+    () => registry.subscribe(rx, f, options),
+    [registry, rx, f, options?.immediate]
+  )
+}
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxRef = <A>(ref: RxRef.ReadonlyRef<A>): A => {
+  const [, setValue] = React.useState(ref.value)
+  React.useEffect(() => ref.subscribe(setValue), [ref])
+  return ref.value
+}
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxRefProp = <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K): RxRef.RxRef<A[K]> =>
+  React.useMemo(() => ref.prop(prop), [ref, prop])
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export const useRxRefPropValue = <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K): A[K] =>
+  useRxRef(useRxRefProp(ref, prop))

--- a/packages/rx-react/src/ReactHydration.ts
+++ b/packages/rx-react/src/ReactHydration.ts
@@ -1,0 +1,23 @@
+"use client"
+/**
+ * @since 1.0.0
+ */
+import * as Hydration from "@effect-rx/rx/Hydration"
+import * as React from "react"
+import { RegistryContext } from "./RegistryContext.js"
+
+/**
+ * @since 1.0.0
+ * @category components
+ */
+
+export const HydrationBoundary: React.FC<{
+  state: Iterable<Hydration.DehydratedRx>
+  children?: React.ReactNode
+}> = ({ children, state }) => {
+  const registry = React.useContext(RegistryContext)
+  React.useEffect(() => {
+    Hydration.hydrate(registry, state)
+  }, [registry, state])
+  return React.createElement(React.Fragment, {}, children)
+}

--- a/packages/rx-react/src/ReactHydration.ts
+++ b/packages/rx-react/src/ReactHydration.ts
@@ -10,7 +10,6 @@ import { RegistryContext } from "./RegistryContext.js"
  * @since 1.0.0
  * @category components
  */
-
 export const HydrationBoundary: React.FC<{
   state: Iterable<Hydration.DehydratedRx>
   children?: React.ReactNode

--- a/packages/rx-react/src/ReactHydration.ts
+++ b/packages/rx-react/src/ReactHydration.ts
@@ -1,7 +1,7 @@
-"use client"
 /**
  * @since 1.0.0
  */
+"use client"
 import * as Hydration from "@effect-rx/rx/Hydration"
 import * as React from "react"
 import { RegistryContext } from "./RegistryContext.js"

--- a/packages/rx-react/src/RegistryContext.ts
+++ b/packages/rx-react/src/RegistryContext.ts
@@ -1,7 +1,7 @@
-"use client"
 /**
  * @since 1.0.0
  */
+"use client"
 import * as Registry from "@effect-rx/rx/Registry"
 import type * as Rx from "@effect-rx/rx/Rx"
 import * as React from "react"

--- a/packages/rx-react/src/RegistryContext.ts
+++ b/packages/rx-react/src/RegistryContext.ts
@@ -3,6 +3,7 @@
  * @since 1.0.0
  */
 import * as Registry from "@effect-rx/rx/Registry"
+import type * as Rx from "@effect-rx/rx/Rx"
 import * as React from "react"
 import * as Scheduler from "scheduler"
 
@@ -22,3 +23,32 @@ export const RegistryContext = React.createContext<Registry.Registry>(Registry.m
   scheduleTask,
   defaultIdleTTL: 400
 }))
+
+/**
+ * @since 1.0.0
+ * @category context
+ */
+export const RegistryProvider = (options: {
+  readonly children?: React.ReactNode | undefined
+  readonly initialValues?: Iterable<readonly [Rx.Rx<any>, any]> | undefined
+  readonly scheduleTask?: ((f: () => void) => void) | undefined
+  readonly timeoutResolution?: number | undefined
+  readonly defaultIdleTTL?: number | undefined
+}) => {
+  const registry = React.useMemo(() =>
+    Registry.make({
+      scheduleTask,
+      defaultIdleTTL: 400,
+      ...options
+    }), [])
+  React.useEffect(() => () => {
+    registry.dispose()
+  }, [registry])
+  return React.createElement(RegistryContext.Provider, {
+    value: Registry.make({
+      scheduleTask,
+      defaultIdleTTL: 400,
+      ...options
+    })
+  }, options?.children)
+}

--- a/packages/rx-react/src/RegistryContext.ts
+++ b/packages/rx-react/src/RegistryContext.ts
@@ -1,0 +1,24 @@
+"use client"
+/**
+ * @since 1.0.0
+ */
+import * as Registry from "@effect-rx/rx/Registry"
+import * as React from "react"
+import * as Scheduler from "scheduler"
+
+/**
+ * @since 1.0.0
+ * @category context
+ */
+export function scheduleTask(f: () => void): void {
+  Scheduler.unstable_scheduleCallback(Scheduler.unstable_LowPriority, f)
+}
+
+/**
+ * @since 1.0.0
+ * @category context
+ */
+export const RegistryContext = React.createContext<Registry.Registry>(Registry.make({
+  scheduleTask,
+  defaultIdleTTL: 400
+}))

--- a/packages/rx-react/src/index.ts
+++ b/packages/rx-react/src/index.ts
@@ -1,314 +1,45 @@
-"use client"
 /**
  * @since 1.0.0
  */
-import * as Registry from "@effect-rx/rx/Registry"
-import * as Result from "@effect-rx/rx/Result"
-import * as Rx from "@effect-rx/rx/Rx"
-import type * as RxRef from "@effect-rx/rx/RxRef"
-import * as Cause from "effect/Cause"
-import type * as Exit from "effect/Exit"
-import { globalValue } from "effect/GlobalValue"
-import * as React from "react"
-import { RegistryContext, scheduleTask } from "./RegistryContext.js"
+
+/**
+ * @since 1.0.0
+ * @category re-exports
+ */
+export * as Rx from "@effect-rx/rx/Rx"
+
+/**
+ * @since 1.0.0
+ * @category re-exports
+ */
+export * as Registry from "@effect-rx/rx/Registry"
+
+/**
+ * @since 1.0.0
+ * @category re-exports
+ */
+export * as Result from "@effect-rx/rx/Registry"
+
+/**
+ * @since 1.0.0
+ * @category re-exports
+ */
+export * as Hydration from "@effect-rx/rx/Hydration"
+
+/**
+ * @since 1.0.0
+ * @category re-exports
+ */
+export * as RxRef from "@effect-rx/rx/RxRef"
+
+/**
+ * @since 1.0.0
+ * @category hooks
+ */
+export * from "./Hooks.js"
 
 /**
  * @since 1.0.0
  * @category context
  */
-export const RegistryProvider = (options: {
-  readonly children?: React.ReactNode | undefined
-  readonly initialValues?: Iterable<readonly [Rx.Rx<any>, any]> | undefined
-  readonly scheduleTask?: ((f: () => void) => void) | undefined
-  readonly timeoutResolution?: number | undefined
-  readonly defaultIdleTTL?: number | undefined
-}) => {
-  const registry = React.useMemo(() =>
-    Registry.make({
-      scheduleTask,
-      defaultIdleTTL: 400,
-      ...options
-    }), [])
-  React.useEffect(() => () => {
-    registry.dispose()
-  }, [registry])
-  return React.createElement(RegistryContext.Provider, {
-    value: Registry.make({
-      scheduleTask,
-      defaultIdleTTL: 400,
-      ...options
-    })
-  }, options?.children)
-}
-
-interface RxStore<A> {
-  readonly subscribe: (f: () => void) => () => void
-  readonly snapshot: () => A
-}
-
-const storeRegistry = globalValue(
-  "@effect-rx/rx-react/storeRegistry",
-  () => new WeakMap<Registry.Registry, WeakMap<Rx.Rx<any>, RxStore<any>>>()
-)
-
-function makeStore<A>(registry: Registry.Registry, rx: Rx.Rx<A>): RxStore<A> {
-  let stores = storeRegistry.get(registry)
-  if (stores === undefined) {
-    stores = new WeakMap()
-    storeRegistry.set(registry, stores)
-  }
-  const store = stores.get(rx)
-  if (store !== undefined) {
-    return store
-  }
-  const newStore: RxStore<A> = {
-    subscribe(f) {
-      return registry.subscribe(rx, f)
-    },
-    snapshot() {
-      return registry.get(rx)
-    }
-  }
-  stores.set(rx, newStore)
-  return newStore
-}
-
-function useStore<A>(registry: Registry.Registry, rx: Rx.Rx<A>): A {
-  const store = makeStore(registry, rx)
-  return React.useSyncExternalStore(store.subscribe, store.snapshot, store.snapshot)
-}
-
-const initialValuesSet = globalValue(
-  "@effect-rx/rx-react/initialValuesSet",
-  () => new WeakMap<Registry.Registry, WeakSet<Rx.Rx<any>>>()
-)
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxInitialValues = (initialValues: Iterable<readonly [Rx.Rx<any>, any]>): void => {
-  const registry = React.useContext(RegistryContext)
-  let set = initialValuesSet.get(registry)
-  if (set === undefined) {
-    set = new WeakSet()
-    initialValuesSet.set(registry, set)
-  }
-  for (const [rx, value] of initialValues) {
-    if (!set.has(rx)) {
-      set.add(rx)
-      ;(registry as any).ensureNode(rx).setValue(value)
-    }
-  }
-}
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxValue: {
-  <A>(rx: Rx.Rx<A>): A
-  <A, B>(rx: Rx.Rx<A>, f: (_: A) => B): B
-} = <A>(rx: Rx.Rx<A>, f?: (_: A) => A): A => {
-  const registry = React.useContext(RegistryContext)
-  if (f) {
-    const rxB = React.useMemo(() => Rx.map(rx, f), [rx, f])
-    return useStore(registry, rxB)
-  }
-  return useStore(registry, rx)
-}
-
-function mountRx<A>(registry: Registry.Registry, rx: Rx.Rx<A>): void {
-  React.useEffect(() => registry.mount(rx), [rx, registry])
-}
-
-function setRx<R, W>(registry: Registry.Registry, rx: Rx.Writable<R, W>): (_: W | ((_: R) => W)) => void {
-  return React.useCallback((value) => {
-    if (typeof value === "function") {
-      registry.set(rx, (value as any)(registry.get(rx)))
-      return
-    } else {
-      registry.set(rx, value)
-    }
-  }, [registry, rx])
-}
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxMount = <A>(rx: Rx.Rx<A>): void => {
-  const registry = React.useContext(RegistryContext)
-  mountRx(registry, rx)
-}
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxSet = <R, W>(rx: Rx.Writable<R, W>): (_: W | ((_: R) => W)) => void => {
-  const registry = React.useContext(RegistryContext)
-  mountRx(registry, rx)
-  return setRx(registry, rx)
-}
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxSetPromise = <E, A, W>(
-  rx: Rx.Writable<Result.Result<A, E>, W>
-): (_: W) => Promise<Exit.Exit<A, E>> => {
-  const registry = React.useContext(RegistryContext)
-  const resolves = React.useMemo(() => new Set<(result: Exit.Exit<A, E>) => void>(), [])
-  React.useEffect(() =>
-    registry.subscribe(rx, (result) => {
-      if (result.waiting || result._tag === "Initial") return
-      const fns = Array.from(resolves)
-      resolves.clear()
-      const exit = Result.toExit(result)
-      fns.forEach((resolve) => resolve(exit as any))
-    }, { immediate: true }), [registry, rx, resolves])
-  return React.useCallback((value) =>
-    new Promise((resolve) => {
-      resolves.add(resolve)
-      registry.set(rx, value)
-    }), [registry, rx, resolves])
-}
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxRefresh = <A>(rx: Rx.Rx<A>): () => void => {
-  const registry = React.useContext(RegistryContext)
-  mountRx(registry, rx)
-  return React.useCallback(() => {
-    registry.refresh(rx)
-  }, [registry, rx])
-}
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRx = <R, W>(
-  rx: Rx.Writable<R, W>
-): readonly [value: R, setOrUpdate: (_: W | ((_: R) => W)) => void] => {
-  const registry = React.useContext(RegistryContext)
-  return [
-    useStore(registry, rx),
-    setRx(registry, rx)
-  ] as const
-}
-
-const rxPromiseMap = globalValue(
-  "@effect-rx/rx-react/rxPromiseMap",
-  () => ({
-    suspendOnWaiting: new Map<Rx.Rx<any>, Promise<void>>(),
-    default: new Map<Rx.Rx<any>, Promise<void>>()
-  })
-)
-
-function rxToPromise<A, E>(
-  registry: Registry.Registry,
-  rx: Rx.Rx<Result.Result<A, E>>,
-  suspendOnWaiting: boolean
-) {
-  const map = suspendOnWaiting ? rxPromiseMap.suspendOnWaiting : rxPromiseMap.default
-  let promise = map.get(rx)
-  if (promise !== undefined) {
-    return promise
-  }
-  promise = new Promise<void>((resolve) => {
-    const dispose = registry.subscribe(rx, (result) => {
-      if (result._tag === "Initial" || (suspendOnWaiting && result.waiting)) {
-        return
-      }
-      setTimeout(dispose, 1000)
-      resolve()
-      map.delete(rx)
-    })
-  })
-  map.set(rx, promise)
-  return promise
-}
-
-function rxResultOrSuspend<A, E>(
-  registry: Registry.Registry,
-  rx: Rx.Rx<Result.Result<A, E>>,
-  suspendOnWaiting: boolean
-) {
-  const value = useStore(registry, rx)
-  if (value._tag === "Initial" || (suspendOnWaiting && value.waiting)) {
-    throw rxToPromise(registry, rx, suspendOnWaiting)
-  }
-  return value
-}
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxSuspense = <A, E>(
-  rx: Rx.Rx<Result.Result<A, E>>,
-  options?: { readonly suspendOnWaiting?: boolean }
-): Result.Success<A, E> | Result.Failure<A, E> => {
-  const registry = React.useContext(RegistryContext)
-  return rxResultOrSuspend(registry, rx, options?.suspendOnWaiting ?? false)
-}
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxSuspenseSuccess = <A, E>(
-  rx: Rx.Rx<Result.Result<A, E>>,
-  options?: { readonly suspendOnWaiting?: boolean }
-): Result.Success<A, E> => {
-  const result = useRxSuspense(rx, options)
-  if (result._tag === "Failure") {
-    throw Cause.squash(result.cause)
-  }
-  return result
-}
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxSubscribe = <A>(
-  rx: Rx.Rx<A>,
-  f: (_: A) => void,
-  options?: { readonly immediate?: boolean }
-): void => {
-  const registry = React.useContext(RegistryContext)
-  React.useEffect(
-    () => registry.subscribe(rx, f, options),
-    [registry, rx, f, options?.immediate]
-  )
-}
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxRef = <A>(ref: RxRef.ReadonlyRef<A>): A => {
-  const [, setValue] = React.useState(ref.value)
-  React.useEffect(() => ref.subscribe(setValue), [ref])
-  return ref.value
-}
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxRefProp = <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K): RxRef.RxRef<A[K]> =>
-  React.useMemo(() => ref.prop(prop), [ref, prop])
-
-/**
- * @since 1.0.0
- * @category hooks
- */
-export const useRxRefPropValue = <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K): A[K] =>
-  useRxRef(useRxRefProp(ref, prop))
+export * from "./RegistryContext.js"

--- a/packages/rx-react/src/index.ts
+++ b/packages/rx-react/src/index.ts
@@ -1,9 +1,7 @@
 "use client"
-import * as Hydration from "@effect-rx/rx/Hydration"
 /**
  * @since 1.0.0
  */
-
 import * as Registry from "@effect-rx/rx/Registry"
 import * as Result from "@effect-rx/rx/Result"
 import * as Rx from "@effect-rx/rx/Rx"
@@ -12,24 +10,7 @@ import * as Cause from "effect/Cause"
 import type * as Exit from "effect/Exit"
 import { globalValue } from "effect/GlobalValue"
 import * as React from "react"
-import * as Scheduler from "scheduler"
-
-/**
- * @since 1.0.0
- * @category context
- */
-export function scheduleTask(f: () => void): void {
-  Scheduler.unstable_scheduleCallback(Scheduler.unstable_LowPriority, f)
-}
-
-/**
- * @since 1.0.0
- * @category context
- */
-export const RegistryContext = React.createContext<Registry.Registry>(Registry.make({
-  scheduleTask,
-  defaultIdleTTL: 400
-}))
+import { RegistryContext, scheduleTask } from "./RegistryContext.js"
 
 /**
  * @since 1.0.0
@@ -331,28 +312,3 @@ export const useRxRefProp = <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K)
  */
 export const useRxRefPropValue = <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K): A[K] =>
   useRxRef(useRxRefProp(ref, prop))
-
-/**
- * @since 1.0.0
- * @category models
- */
-export interface HydrationBoundaryProps {
-  readonly state: Hydration.DehydratedState
-  readonly children?: React.ReactNode
-}
-
-/**
- * @since 1.0.0
- * @category components
- */
-
-export const HydrationBoundary: React.FC<{
-  state: Hydration.DehydratedState
-  children?: React.ReactNode
-}> = ({ children, state }) => {
-  const registry = React.useContext(RegistryContext)
-  React.useEffect(() => {
-    Hydration.hydrate(registry, state)
-  }, [registry, state])
-  return React.createElement(React.Fragment, {}, children)
-}

--- a/packages/rx-react/src/index.ts
+++ b/packages/rx-react/src/index.ts
@@ -1,3 +1,5 @@
+"use client"
+import * as Hydration from "@effect-rx/rx/Hydration"
 /**
  * @since 1.0.0
  */
@@ -11,27 +13,6 @@ import type * as Exit from "effect/Exit"
 import { globalValue } from "effect/GlobalValue"
 import * as React from "react"
 import * as Scheduler from "scheduler"
-
-/**
- * @since 1.0.0
- * @category modules
- */
-export * as Registry from "@effect-rx/rx/Registry"
-/**
- * @since 1.0.0
- * @category modules
- */
-export * as Result from "@effect-rx/rx/Result"
-/**
- * @since 1.0.0
- * @category modules
- */
-export * as Rx from "@effect-rx/rx/Rx"
-/**
- * @since 1.0.0
- * @category modules
- */
-export * as RxRef from "@effect-rx/rx/RxRef"
 
 /**
  * @since 1.0.0
@@ -350,3 +331,28 @@ export const useRxRefProp = <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K)
  */
 export const useRxRefPropValue = <A, K extends keyof A>(ref: RxRef.RxRef<A>, prop: K): A[K] =>
   useRxRef(useRxRefProp(ref, prop))
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
+export interface HydrationBoundaryProps {
+  readonly state: Hydration.DehydratedState
+  readonly children?: React.ReactNode
+}
+
+/**
+ * @since 1.0.0
+ * @category components
+ */
+
+export const HydrationBoundary: React.FC<{
+  state: Hydration.DehydratedState
+  children?: React.ReactNode
+}> = ({ children, state }) => {
+  const registry = React.useContext(RegistryContext)
+  React.useEffect(() => {
+    Hydration.hydrate(registry, state)
+  }, [registry, state])
+  return React.createElement(React.Fragment, {}, children)
+}

--- a/packages/rx/package.json
+++ b/packages/rx/package.json
@@ -3,9 +3,17 @@
   "version": "0.44.0",
   "description": "Reactive toolkit for Effect",
   "type": "module",
-  "publishConfig": {
-    "access": "public",
-    "directory": "dist"
+  "exports": {
+    ".": {
+      "import": "./build/esm/index.js",
+      "require": "./build/cjs/index.js",
+      "types": "./build/dts/index.d.ts"
+    },
+    "./*": {
+      "import": "./build/esm/*.js",
+      "require": "./build/cjs/*.js",
+      "types": "./build/dts/*.d.ts"
+    }
   },
   "repository": {
     "type": "git",
@@ -13,6 +21,7 @@
   },
   "homepage": "https://github.com/effect-ts/rx",
   "scripts": {
+    "build:watch": "tsc -b tsconfig.build.json --watch",
     "build": "pnpm build-prepare && pnpm build-esm && pnpm build-cjs && pnpm build-annotate && build-utils pack-v2",
     "build-prepare": "build-utils prepare-v2",
     "build-esm": "tsc -b tsconfig.build.json",

--- a/packages/rx/package.json
+++ b/packages/rx/package.json
@@ -3,17 +3,9 @@
   "version": "0.44.0",
   "description": "Reactive toolkit for Effect",
   "type": "module",
-  "exports": {
-    ".": {
-      "import": "./build/esm/index.js",
-      "require": "./build/cjs/index.js",
-      "types": "./build/dts/index.d.ts"
-    },
-    "./*": {
-      "import": "./build/esm/*.js",
-      "require": "./build/cjs/*.js",
-      "types": "./build/dts/*.d.ts"
-    }
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
   },
   "repository": {
     "type": "git",
@@ -21,7 +13,6 @@
   },
   "homepage": "https://github.com/effect-ts/rx",
   "scripts": {
-    "build:watch": "tsc -b tsconfig.build.json --watch",
     "build": "pnpm build-prepare && pnpm build-esm && pnpm build-cjs && pnpm build-annotate && build-utils pack-v2",
     "build-prepare": "build-utils prepare-v2",
     "build-esm": "tsc -b tsconfig.build.json",

--- a/packages/rx/src/Hydration.ts
+++ b/packages/rx/src/Hydration.ts
@@ -1,0 +1,98 @@
+/**
+ * @since 1.0.0
+ */
+import type * as Registry from "./Registry.js"
+import type * as Result from "./Result.js"
+import * as Rx from "./Rx.js"
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
+export interface DehydratedRx<A = unknown, E = unknown> {
+  readonly rxKey: string
+  readonly state: Result.Result<A, E>
+  readonly dehydratedAt: number
+}
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
+export interface DehydratedState {
+  readonly rxs: ReadonlyArray<DehydratedRx>
+}
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
+export interface DehydrateOptions {
+  readonly shouldDehydrateRx?: (rx: Rx.Rx<any>) => boolean
+}
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
+export interface HydrateOptions {
+  readonly shouldHydrateRx?: (rx: Rx.Rx<any>, dehydratedRx: DehydratedRx) => boolean
+}
+
+/**
+ * @since 1.0.0
+ * @category dehydration
+ */
+export const dehydrate = (
+  registry: Registry.Registry,
+  options?: DehydrateOptions
+): DehydratedState => {
+  return (registry as any).dehydrate(options)
+}
+
+/**
+ * @since 1.0.0
+ * @category hydration
+ */
+export const hydrate = (
+  registry: Registry.Registry,
+  dehydratedState: DehydratedState,
+  options?: HydrateOptions
+): void => {
+  return (registry as any).hydrate(dehydratedState, options)
+}
+
+/**
+ * @since 1.0.0
+ * @category utilities
+ */
+export const getRxKey = (rx: Rx.Rx<any>): string => {
+  // Use the rx's label if available, otherwise use a hash of the rx object
+  if (rx.label) {
+    return rx.label[0]
+  }
+
+  throw new Error("to dehydrate an rx, it must have a label")
+}
+
+/**
+ * @since 1.0.0
+ * @category utilities
+ */
+export const isDehydratedStateEmpty = (state: DehydratedState): boolean => {
+  return state.rxs.length === 0
+}
+
+/**
+ * @since 1.0.0
+ * @category utilities
+ */
+export const createDehydratedState = (
+  rxs: ReadonlyArray<DehydratedRx> = []
+): DehydratedState => ({
+  rxs
+})
+
+export const defaultShouldDehydrateRx = (rx: Rx.Rx<any>): boolean => {
+  return Rx.isSerializable(rx)
+}

--- a/packages/rx/src/Registry.ts
+++ b/packages/rx/src/Registry.ts
@@ -32,10 +32,12 @@ export type TypeId = typeof TypeId
  */
 export interface Registry {
   readonly [TypeId]: TypeId
+  readonly getNodes: () => ReadonlyMap<Rx.Rx<any> | string, Node<any>>
   readonly get: <A>(rx: Rx.Rx<A>) => A
   readonly mount: <A>(rx: Rx.Rx<A>) => () => void
   readonly refresh: <A>(rx: Rx.Rx<A>) => void
   readonly set: <R, W>(rx: Rx.Writable<R, W>, value: W) => void
+  readonly setSerializable: (key: string, encoded: unknown) => void
   readonly modify: <R, W, A>(rx: Rx.Writable<R, W>, f: (_: R) => [returnValue: A, nextValue: W]) => A
   readonly update: <R, W>(rx: Rx.Writable<R, W>, f: (_: R) => W) => void
   readonly subscribe: <A>(rx: Rx.Rx<A>, f: (_: A) => void, options?: {
@@ -43,6 +45,15 @@ export interface Registry {
   }) => () => void
   readonly reset: () => void
   readonly dispose: () => void
+}
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
+interface Node<A> {
+  readonly rx: Rx.Rx<A>
+  readonly value: () => A
 }
 
 /**

--- a/packages/rx/src/Registry.ts
+++ b/packages/rx/src/Registry.ts
@@ -150,11 +150,11 @@ export const toStream: {
  * @category Conversions
  */
 export const toStreamResult: {
-  <A, E>(rx: Rx.Rx<Result.Result<A, E>>): (self: Registry) => Stream.Stream<A, E, RxRegistry>
-  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>): Stream.Stream<A, E, RxRegistry>
+  <A, E>(rx: Rx.Rx<Result.Result<A, E>>): (self: Registry) => Stream.Stream<A, E>
+  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>): Stream.Stream<A, E>
 } = dual(
   2,
-  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>): Stream.Stream<A, E, RxRegistry> =>
+  <A, E>(self: Registry, rx: Rx.Rx<Result.Result<A, E>>): Stream.Stream<A, E> =>
     toStream(self, rx).pipe(
       Stream.filter(Result.isNotInitial),
       Stream.mapEffect((result) =>

--- a/packages/rx/src/Rx.ts
+++ b/packages/rx/src/Rx.ts
@@ -84,6 +84,12 @@ export declare namespace Rx {
    * @since 1.0.0
    */
   export type InferFailure<T extends Rx<any>> = T extends Rx<Result.Result<infer _, infer E>> ? E : never
+
+  /**
+   * @since 1.0.0
+   */
+  export type WithoutSerializable<T extends Rx<any>> = T extends Writable<infer R, infer W> ? Writable<R, W>
+    : Rx<Infer<T>>
 }
 
 /**
@@ -1328,8 +1334,8 @@ export const mapResult: {
  * @category combinators
  */
 export const debounce: {
-  (duration: Duration.DurationInput): <A extends Rx<any>>(self: A) => A
-  <A extends Rx<any>>(self: A, duration: Duration.DurationInput): A
+  (duration: Duration.DurationInput): <A extends Rx<any>>(self: A) => Rx.WithoutSerializable<A>
+  <A extends Rx<any>>(self: A, duration: Duration.DurationInput): Rx.WithoutSerializable<A>
 } = dual(
   2,
   <A>(self: Rx<A>, duration: Duration.DurationInput): Rx<A> => {
@@ -1386,7 +1392,7 @@ export const windowFocusSignal: Rx<number> = readable((get) => {
  * @since 1.0.0
  * @category Focus
  */
-export const makeRefreshOnSignal = <_>(signal: Rx<_>) => <A extends Rx<any>>(self: A): A =>
+export const makeRefreshOnSignal = <_>(signal: Rx<_>) => <A extends Rx<any>>(self: A): Rx.WithoutSerializable<A> =>
   transform(self, (get) => {
     get.subscribe(signal, (_) => get.refresh(self))
     get.subscribe(self, (value) => get.setSelf(value))
@@ -1397,7 +1403,7 @@ export const makeRefreshOnSignal = <_>(signal: Rx<_>) => <A extends Rx<any>>(sel
  * @since 1.0.0
  * @category combinators
  */
-export const refreshOnWindowFocus: <A extends Rx<any>>(self: A) => A = makeRefreshOnSignal(
+export const refreshOnWindowFocus: <A extends Rx<any>>(self: A) => Rx.WithoutSerializable<A> = makeRefreshOnSignal(
   windowFocusSignal
 )
 
@@ -1597,48 +1603,63 @@ export const getResult = <A, E>(
 export const refresh = <A>(self: Rx<A>): Effect.Effect<void, never, RxRegistry> =>
   Effect.map(RxRegistry, (_) => _.refresh(self))
 
+// -----------------------------------------------------------------------------
+// Serializable
+// -----------------------------------------------------------------------------
+
 /**
  * @since 1.0.0
- * @category type ids
+ * @category Serializable
  */
 export const SerializableTypeId = Symbol.for("@effect-rx/rx/Rx/Serializable")
 
 /**
  * @since 1.0.0
- * @category type ids
+ * @category Serializable
  */
 export type SerializableTypeId = typeof SerializableTypeId
 
 /**
  * @since 1.0.0
- * @category models
+ * @category Serializable
  */
 export interface Serializable {
-  readonly [SerializableTypeId]: SerializableTypeId
+  readonly [SerializableTypeId]: {
+    readonly key: string
+    readonly encode: (value: unknown) => unknown
+    readonly decode: (value: unknown) => unknown
+  }
 }
 
-export const isSerializable = (self: Rx<any>): self is Rx<any> & Serializable => {
-  return SerializableTypeId in self && self[SerializableTypeId] === SerializableTypeId
-}
+/**
+ * @since 1.0.0
+ * @category Serializable
+ */
+export const isSerializable = (self: Rx<any>): self is Rx<any> & Serializable => SerializableTypeId in self
 
 /**
  * @since 1.0.0
  * @category combinators
  */
 export const serializable: {
-  <A, I>(schema: Schema.Schema<A, I>): <R extends Rx<any>>(self: R) => R & Serializable
-  <R extends Rx<any>, A, I>(self: R, schema: Schema.Schema<A, I>): R & Serializable
-} = dual<
-  <A, I>(schema: Schema.Schema<A, I>) => <R extends Rx<any>>(self: R) => R & Serializable,
-  <R extends Rx<any>, A, I>(self: R, schema: Schema.Schema<A, I>) => R & Serializable
->(2, (self, schema) => {
-  const encode = Schema.encodeSync(schema)
-  const decode = Schema.decodeSync(schema)
-
-  return Object.assign(Object.create(Object.getPrototypeOf(self)), {
+  <R extends Rx<any>, I>(options: {
+    readonly key: string
+    readonly schema: Schema.Schema<Rx.Infer<R>, I>
+  }): (self: R) => R & Serializable
+  <R extends Rx<any>, I>(self: R, options: {
+    readonly key: string
+    readonly schema: Schema.Schema<Rx.Infer<R>, I>
+  }): R & Serializable
+} = dual(2, <R extends Rx<any>, A, I>(self: R, options: {
+  readonly key: string
+  readonly schema: Schema.Schema<A, I>
+}): R & Serializable =>
+  Object.assign(Object.create(Object.getPrototypeOf(self)), {
     ...self,
-    [SerializableTypeId]: SerializableTypeId,
-    serialize: (value: any) => encode(value),
-    deserialize: (value: any) => decode(value)
-  })
-})
+    label: self.label ?? [options.key, new Error().stack?.split("\n")[5] ?? ""],
+    [SerializableTypeId]: {
+      key: options.key,
+      encode: Schema.encodeSync(options.schema),
+      decode: Schema.decodeSync(options.schema)
+    }
+  }))

--- a/packages/rx/src/index.ts
+++ b/packages/rx/src/index.ts
@@ -17,3 +17,8 @@ export * as Rx from "./Rx.js"
  * @since 1.0.0
  */
 export * as RxRef from "./RxRef.js"
+
+/**
+ * @since 1.0.0
+ */
+export * as Hydration from "./Hydration.js"

--- a/packages/rx/src/internal/registry.ts
+++ b/packages/rx/src/internal/registry.ts
@@ -276,7 +276,7 @@ const enum NodeState {
 class Node<A> {
   constructor(
     readonly registry: RegistryImpl,
-    public rx: Rx.Rx<A>
+    readonly rx: Rx.Rx<A>
   ) {
     this.writeContext = new WriteContextImpl(registry, this)
   }

--- a/packages/rx/test/Rx.test.ts
+++ b/packages/rx/test/Rx.test.ts
@@ -947,78 +947,74 @@ describe("Rx", () => {
     const notSerializable = Rx.make(0)
     r.mount(notSerializable)
 
-    const basicSerializable = Rx.make(0).pipe(Rx.serializable(Schema.Number), Rx.withLabel("basicSerializable"))
+    const basicSerializable = Rx.make(0).pipe(Rx.serializable({
+      key: "basicSerializable",
+      schema: Schema.Number
+    }))
     r.mount(basicSerializable)
 
-    const errored = Rx.make(Effect.fail("error")).pipe(Rx.serializable(Schema.String), Rx.withLabel("errored"))
+    const errored = Rx.make(Effect.fail("error")).pipe(
+      Rx.serializable({
+        key: "errored",
+        schema: Result.Schema({
+          error: Schema.String
+        })
+      })
+    )
     r.mount(errored)
 
-    const success = Rx.make(Effect.succeed(123)).pipe(Rx.serializable(Schema.Number), Rx.withLabel("success"))
+    const success = Rx.make(Effect.succeed(123)).pipe(Rx.serializable({
+      key: "success",
+      schema: Result.Schema({
+        success: Schema.Number
+      })
+    }))
     r.mount(success)
 
-    const pending = Rx.make(Effect.never).pipe(Rx.serializable(Schema.Number), Rx.withLabel("pending"))
+    const pending = Rx.make(Effect.never).pipe(Rx.serializable({
+      key: "pending",
+      schema: Result.Schema({})
+    }))
     r.mount(pending)
 
     const state = Hydration.dehydrate(r)
-    expect(state.rxs.map((r) => Struct.omit(r, "dehydratedAt"))).toMatchInlineSnapshot(`
+    expect(state.map((r) => Struct.omit(r, "dehydratedAt"))).toMatchInlineSnapshot(`
       [
         {
-          "rxKey": "basicSerializable",
-          "state": 0,
+          "key": "basicSerializable",
+          "value": 0,
         },
         {
-          "rxKey": "errored",
-          "state": {
+          "key": "errored",
+          "value": {
             "_tag": "Failure",
             "cause": {
-              "_id": "Cause",
               "_tag": "Fail",
-              "failure": "error",
+              "error": "error",
             },
             "previousValue": {
-              "_id": "Option",
               "_tag": "None",
             },
             "waiting": false,
           },
         },
         {
-          "rxKey": "success",
-          "state": {
+          "key": "success",
+          "value": {
             "_tag": "Success",
             "value": 123,
             "waiting": false,
           },
         },
         {
-          "rxKey": "pending",
-          "state": {
+          "key": "pending",
+          "value": {
             "_tag": "Initial",
             "waiting": true,
           },
         },
       ]
     `)
-  })
-
-  it("hydrate", async () => {
-    const r = Registry.make()
-    const notSerializable = Rx.make(0)
-    r.mount(notSerializable)
-
-    const basicSerializable = Rx.make(0).pipe(Rx.serializable(Schema.Number), Rx.withLabel("basicSerializable"))
-    r.mount(basicSerializable)
-
-    const errored = Rx.make(Effect.fail("error")).pipe(Rx.serializable(Schema.String), Rx.withLabel("errored"))
-    r.mount(errored)
-
-    const success = Rx.make(Effect.succeed(123)).pipe(Rx.serializable(Schema.Number), Rx.withLabel("success"))
-    r.mount(success)
-
-    const pending = Rx.make(Effect.never).pipe(Rx.serializable(Schema.Number), Rx.withLabel("pending"))
-    r.mount(pending)
-
-    const state = Hydration.dehydrate(r)
 
     const r2 = Registry.make()
     Hydration.hydrate(r2, state)

--- a/packages/rx/test/Rx.test.ts
+++ b/packages/rx/test/Rx.test.ts
@@ -1,7 +1,8 @@
+import * as Hydration from "@effect-rx/rx/Hydration"
 import * as Registry from "@effect-rx/rx/Registry"
 import * as Result from "@effect-rx/rx/Result"
 import * as Rx from "@effect-rx/rx/Rx"
-import { Cause, Either, FiberRef, Subscribable, SubscriptionRef } from "effect"
+import { Cause, Either, FiberRef, Schema, Struct, Subscribable, SubscriptionRef } from "effect"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Hash from "effect/Hash"
@@ -939,6 +940,94 @@ describe("Rx", () => {
 
     r.set(signal, 1)
     assert.strictEqual(rebuilds, 2)
+  })
+
+  it("dehydrate", async () => {
+    const r = Registry.make()
+    const notSerializable = Rx.make(0)
+    r.mount(notSerializable)
+
+    const basicSerializable = Rx.make(0).pipe(Rx.serializable(Schema.Number), Rx.withLabel("basicSerializable"))
+    r.mount(basicSerializable)
+
+    const errored = Rx.make(Effect.fail("error")).pipe(Rx.serializable(Schema.String), Rx.withLabel("errored"))
+    r.mount(errored)
+
+    const success = Rx.make(Effect.succeed(123)).pipe(Rx.serializable(Schema.Number), Rx.withLabel("success"))
+    r.mount(success)
+
+    const pending = Rx.make(Effect.never).pipe(Rx.serializable(Schema.Number), Rx.withLabel("pending"))
+    r.mount(pending)
+
+    const state = Hydration.dehydrate(r)
+    expect(state.rxs.map((r) => Struct.omit(r, "dehydratedAt"))).toMatchInlineSnapshot(`
+      [
+        {
+          "rxKey": "basicSerializable",
+          "state": 0,
+        },
+        {
+          "rxKey": "errored",
+          "state": {
+            "_tag": "Failure",
+            "cause": {
+              "_id": "Cause",
+              "_tag": "Fail",
+              "failure": "error",
+            },
+            "previousValue": {
+              "_id": "Option",
+              "_tag": "None",
+            },
+            "waiting": false,
+          },
+        },
+        {
+          "rxKey": "success",
+          "state": {
+            "_tag": "Success",
+            "value": 123,
+            "waiting": false,
+          },
+        },
+        {
+          "rxKey": "pending",
+          "state": {
+            "_tag": "Initial",
+            "waiting": true,
+          },
+        },
+      ]
+    `)
+  })
+
+  it("hydrate", async () => {
+    const r = Registry.make()
+    const notSerializable = Rx.make(0)
+    r.mount(notSerializable)
+
+    const basicSerializable = Rx.make(0).pipe(Rx.serializable(Schema.Number), Rx.withLabel("basicSerializable"))
+    r.mount(basicSerializable)
+
+    const errored = Rx.make(Effect.fail("error")).pipe(Rx.serializable(Schema.String), Rx.withLabel("errored"))
+    r.mount(errored)
+
+    const success = Rx.make(Effect.succeed(123)).pipe(Rx.serializable(Schema.Number), Rx.withLabel("success"))
+    r.mount(success)
+
+    const pending = Rx.make(Effect.never).pipe(Rx.serializable(Schema.Number), Rx.withLabel("pending"))
+    r.mount(pending)
+
+    const state = Hydration.dehydrate(r)
+
+    const r2 = Registry.make()
+    Hydration.hydrate(r2, state)
+
+    expect(r2.get(notSerializable)).toEqual(0)
+    expect(r2.get(basicSerializable)).toEqual(0)
+    expect(r2.get(errored)).toEqual(Result.failure(Cause.fail("error")))
+    expect(r2.get(success)).toEqual(Result.success(123))
+    expect(r2.get(pending)).toEqual(Result.initial(true))
   })
 })
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "NodeNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": [],
     "isolatedModules": true,
     "sourceMap": true,
     "declarationMap": true,


### PR DESCRIPTION
### initial draft of hydration support
heavily inspired by react query's api:
https://tanstack.com/query/v5/docs/framework/react/guides/ssr#using-the-hydration-apis
https://tanstack.com/query/v5/docs/framework/react/guides/advanced-ssr
https://github.com/TanStack/query/blob/bf77ab7e4878a4230b4d7632bea53cbd2e7dd162/packages/react-query/src/HydrationBoundary.tsx
https://github.com/TanStack/query/blob/bf77ab7e4878a4230b4d7632bea53cbd2e7dd162/packages/react-query/src/QueryClientProvider.tsx

super jank but it does actually work!
my little test repo: https://github.com/ethanniser/rx-hydration-test

this whole thing kind of requires referring to rx'es by label instead of object reference. I think its fine to require this- maybe we can enforce it as part of `Rx.serializable` or something

Also the reason I had to remove the reexports was they are incompatible with "use client"

We need the hydration boundary and the createContext to be use client and we also want to be able to use the normal rx module in server modules so I think you'll just have to import from both  

Also adding a Registry.getPromise or something would be very helpful for prefetching in a server component where you have to await as opposed to the janky new Promise subscribe thing I did in my example app

todos:
- [ ] decide on general api design 
- [ ] better hueristic for when to serialize / deserialize rx'es (can look at what react query does)
- [ ] use rx schema for serialization/deserialization
- [ ] pass a promise for pending rx'es which can be sent over the wire by react (again heavily inspired by react query)
- [ ] use async iterables to send streams across hydration boundary ~~(maybe react could support async interables in addition to promises?)~~
- [ ] vue support?