### PR TITLE
properly handle react SSR

### DIFF
--- a/packages/rx-react/package.json
+++ b/packages/rx-react/package.json
@@ -27,10 +27,12 @@
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.7",
     "@types/scheduler": "^0.26.0",
     "effect": "^3.17.2",
     "jsdom": "^26.1.0",
     "react": "^19.1.1",
+    "react-dom": "^19.1.1",
     "react-error-boundary": "^6.0.0",
     "scheduler": "^0.26.0"
   },

--- a/packages/rx-react/src/Hooks.ts
+++ b/packages/rx-react/src/Hooks.ts
@@ -3,7 +3,7 @@
  */
 "use client"
 import * as Registry from "@effect-rx/rx/Registry"
-import * as Result from "@effect-rx/rx/Result"
+import type * as Result from "@effect-rx/rx/Result"
 import * as Rx from "@effect-rx/rx/Rx"
 import type * as RxRef from "@effect-rx/rx/RxRef"
 import { Effect } from "effect"
@@ -24,10 +24,7 @@ const storeRegistry = globalValue(
   () => new WeakMap<Registry.Registry, WeakMap<Rx.Rx<any>, RxStore<any>>>()
 )
 
-const makeStore: {
-  <A>(registry: Registry.Registry, rx: Rx.Rx<A>): RxStore<A>
-  <A, E>(registry: Registry.Registry, rx: Rx.Rx<Result.Result<A, E>>): RxStore<Result.Result<A, E>>
-} = (registry: Registry.Registry, rx: Rx.Rx<any>) => {
+function makeStore<A>(registry: Registry.Registry, rx: Rx.Rx<A>): RxStore<A> {
   let stores = storeRegistry.get(registry)
   if (stores === undefined) {
     stores = new WeakMap()
@@ -45,10 +42,10 @@ const makeStore: {
       return registry.get(rx)
     },
     getServerSnapshot() {
-      // if (Rx.isResultRx(rx)) {
-      return Result.initial(true)
-      // }
-      // return this.snapshot()
+      if (Rx.isHasServerSnapshot(rx)) {
+        return rx.getServerSnapshot()
+      }
+      return registry.get(rx)
     }
   }
   stores.set(rx, newStore)

--- a/packages/rx/src/Rx.ts
+++ b/packages/rx/src/Rx.ts
@@ -1800,3 +1800,45 @@ export const serializable: {
       decode: Schema.decodeSync(options.schema)
     }
   }))
+
+/**
+ * @since 1.0.0
+ * @category type ids
+ */
+export const HasServerSnapshotTypeId = Symbol.for("@effect-rx/rx/Rx/HasServerSnapshot")
+
+/**
+ * @since 1.0.0
+ * @category type ids
+ */
+export type HasServerSnapshotTypeId = typeof HasServerSnapshotTypeId
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
+export interface HasServerSnapshot<A> {
+  readonly [HasServerSnapshotTypeId]: HasServerSnapshotTypeId
+  readonly getServerSnapshot: () => A
+}
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
+export const isHasServerSnapshot = (self: Rx<any>): self is Rx<any> & HasServerSnapshot<any> =>
+  HasServerSnapshotTypeId in self
+
+/**
+ * @since 1.0.0
+ * @category combinators
+ */
+export const withServerSnapshot: {
+  <A>(getServerSnapshot: () => A): (rx: Rx<A>) => Rx<A> & HasServerSnapshot<A>
+  <A>(rx: Rx<A>, getServerSnapshot: () => A): Rx<A> & HasServerSnapshot<A>
+} = dual(2, <A>(rx: Rx<A>, getServerSnapshot: () => A): Rx<A> & HasServerSnapshot<A> => {
+  return Object.assign(Object.create(Object.getPrototypeOf(rx)), {
+    [HasServerSnapshotTypeId]: HasServerSnapshotTypeId,
+    getServerSnapshot
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,10 +143,13 @@ importers:
         version: 6.6.4
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react@19.1.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.8
+      '@types/react-dom':
+        specifier: ^19.1.7
+        version: 19.1.7(@types/react@19.1.8)
       '@types/scheduler':
         specifier: ^0.26.0
         version: 0.26.0
@@ -159,6 +162,9 @@ importers:
       react:
         specifier: ^19.1.1
         version: 19.1.1
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.1.1(react@19.1.1)
       react-error-boundary:
         specifier: ^6.0.0
         version: 6.0.0(react@19.1.1)
@@ -1233,6 +1239,11 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/react-dom@19.1.7':
+    resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
+    peerDependencies:
+      '@types/react': ^19.0.0
 
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
@@ -5093,7 +5104,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react@19.1.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@babel/runtime': 7.28.2
       '@testing-library/dom': 10.4.1
@@ -5101,6 +5112,7 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.8
+      '@types/react-dom': 19.1.7(@types/react@19.1.8)
 
   '@ts-graphviz/adapter@2.0.6':
     dependencies:
@@ -5198,6 +5210,10 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/react-dom@19.1.7(@types/react@19.1.8)':
+    dependencies:
+      '@types/react': 19.1.8
 
   '@types/react@19.1.8':
     dependencies:


### PR DESCRIPTION
closes #246

originally I wanted to try to determine at rx construction time if it was a `Result` rx or not and use that to determine when `getServerSnapshot` calls `registry.get` or just returns `Result.initial(true)`

but im not sure if this is possible
this combinator approach works but you kinda have to put it everywhere- but honestly theres value in having a server snapshot for non-result rx's as well (same use cases as useSyncExternalStore) so things like media queries or intersection observers, etc

the types are super messed up though it is infering the rx type from the snapshot fn not the original rx
also probably you should be able to return a effect in the snapshot function as well