### PR TITLE
fix refresh skip invalidation

### DIFF
--- a/.changeset/refresh-derived-invalidation.md
+++ b/.changeset/refresh-derived-invalidation.md
@@ -1,0 +1,5 @@
+---
+"@effect-atom/atom": patch
+---
+
+ensure refreshed lazy parents invalidate newly mounted children

--- a/packages/atom/src/internal/registry.ts
+++ b/packages/atom/src/internal/registry.ts
@@ -376,6 +376,9 @@ class Node<A> {
 
     if (parent.children.indexOf(this) === -1) {
       parent.children.push(this)
+      if (parent.skipInvalidation) {
+        parent.skipInvalidation = false
+      }
     }
   }
 


### PR DESCRIPTION
prevent refresh-ing lazy atoms from dropping downstream invalidations when a dependent mounts later